### PR TITLE
Features/service registry version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ htmlcov/
 .idea/workspace.xml
 .idea/dataSources*
 /chord_services.json
+.vscode

--- a/bento_service_registry/app.py
+++ b/bento_service_registry/app.py
@@ -79,7 +79,8 @@ with application.app_context():
         "environment": "prod"
     }
 
-    chord_services = get_chord_services()   # Not a constant: can change when a service is updated
+    chord_services_content = get_chord_services()   # Not a constant: can change when a service is updated
+
 
 
 def get_service(service_artifact):
@@ -149,7 +150,7 @@ def chord_services():
 
 def _services():
     return [s for s in (
-        get_service(s["type"]["artifact"]) for s in chord_services
+        get_service(s["type"]["artifact"]) for s in chord_services_content
         ) if s is not None]
 
 
@@ -160,7 +161,7 @@ def services():
 
 @application.route("/services/<string:service_id>")
 def service_by_id(service_id):
-    services_by_id = {s["id"]: s for s in chord_services.values()}
+    services_by_id = {s["id"]: s for s in chord_services_content.values()}
     if service_id not in services_by_id:
         return flask_not_found_error(f"Service with ID {service_id} was not found in registry")
 

--- a/bento_service_registry/app.py
+++ b/bento_service_registry/app.py
@@ -82,7 +82,6 @@ with application.app_context():
     chord_services_content = get_chord_services()   # Not a constant: can change when a service is updated
 
 
-
 def get_service(service_artifact):
     # special case: requesting info about the current service. Avoids request timeout
     # when running gunicorn on a single worker
@@ -110,13 +109,13 @@ def get_service(service_artifact):
 
         if r.status_code != 200:
             print(f"[{SERVICE_NAME}] Non-200 status code on {service_artifact}: {r.status_code}\n"
-                    f"                 Content: {r.text}", file=sys.stderr, flush=True)
+                  f"                 Content: {r.text}", file=sys.stderr, flush=True)
 
             # If we have the special case where we got a JWT error from the proxy script, we can safely print out
             # headers for debugging, since the JWT leaked isn't valid anyway.
             if "invalid jwt" in r.text:
                 print(f"                 Encountered auth error, tried to use header: {auth_header}",
-                        file=sys.stderr, flush=True)
+                      file=sys.stderr, flush=True)
 
             return None
 
@@ -195,6 +194,7 @@ def _service_info():
         print("Error in dev-mode retrieving git information", except_name)
 
     return info  # updated service info with the git info
+
 
 @application.route("/service-info")
 def service_info():

--- a/bento_service_registry/app.py
+++ b/bento_service_registry/app.py
@@ -145,7 +145,7 @@ def before_first_request_func():
 @application.route("/bento-services")
 @application.route("/chord-services")
 def chord_services():
-    jsonify(get_chord_services())
+    return jsonify(get_chord_services())
 
 
 def _services():
@@ -161,17 +161,17 @@ def services():
 
 @application.route("/services/<string:service_id>")
 def service_by_id(service_id):
-    services_by_id = {s["id"]: s for s in chord_services_content.values()}
+    services_by_id = {s["id"]: s for s in _services()}
     if service_id not in services_by_id:
         return flask_not_found_error(f"Service with ID {service_id} was not found in registry")
 
-    service_artifact = services_by_id[service_id]["type"]["artifact"]
+    service_artifact = services_by_id[service_id]["type"].split(":")[1]
     return get_service(service_artifact)
 
 
 @application.route("/services/types")
 def service_types():
-    return jsonify(sorted(set(s["type"] for s in _services().values())))
+    return jsonify(sorted(set(s["type"] for s in _services())))
 
 
 def _service_info():

--- a/bento_service_registry/package.cfg
+++ b/bento_service_registry/package.cfg
@@ -1,5 +1,5 @@
 [package]
 name = bento_service_registry
-version = 0.5.1
+version = 0.6.0
 authors = David Lougheed
 author_emails = david.lougheed@mail.mcgill.ca

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "bento_lib[flask]==2.2.1",
-        "Flask>=1.1.2,<2.0", 
+        "Flask>=1.1.2,<2.0",
         "requests>=2.25.1,<3.0",
     ],
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 def _setup_env():
     os.environ["CHORD_SERVICES"] = os.path.join(os.path.dirname(__file__), "chord_services.json")
     os.environ["URL_PATH_FORMAT"] = ""  # Mount off of root URL for testing
+    os.environ["CHORD_DEBUG"] = ""
 
 
 @pytest.fixture()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,7 @@ def test_service_info(client, service_info):
     d = r.get_json()
     # TODO: Check against service-info schema
     assert r.status_code == 200
-    assert json.dumps(d, sort_keys=True) == json.dumps(service_info, sort_keys=True)
+    assert d == service_info
 
 
 def test_chord_service_list(client):
@@ -22,20 +22,14 @@ def test_service_list(client, service_info):
     d = r.get_json()
     assert r.status_code == 200
     assert len(d) == 1
-    assert json.dumps(d[0], sort_keys=True) == json.dumps({
-        **service_info,
-        "url": "http://127.0.0.1:5000/"
-    }, sort_keys=True)
+    assert d[0] == service_info
 
 
 def test_service_detail(client, service_info):
     r = client.get(f"/services/{service_info['id']}")
     d = r.get_json()
     assert r.status_code == 200
-    assert json.dumps(d, sort_keys=True) == json.dumps({
-        **service_info,
-        "url": "http://127.0.0.1:5000/"
-    }, sort_keys=True)
+    assert d == service_info
 
     r = client.get("/services/does-not-exist")
     assert r.status_code == 404

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,3 @@
-import json
-
-
 def test_service_info(client, service_info):
     r = client.get("/service-info")
     d = r.get_json()


### PR DESCRIPTION
-In app.py in the route /service-info, a check was added for environment mode; if it is in dev mode will run a subprocess to retrieve information from git_branch and git_tag. The information about the environment mode is obtained from config BENTO_DEBUG

-The response from /service-info should contain git information and <environment: dev> information when make run-service-registry-dev is executed

-The cache was removed from the get_service function, allowing to obtain updated information from chord-services.

